### PR TITLE
Fix hardcoded API URLs

### DIFF
--- a/src/components/FillContract.js
+++ b/src/components/FillContract.js
@@ -14,7 +14,7 @@ function FillContract() {
 
   useEffect(() => {
     // fetch active contract URL to preview
-    fetch('http://localhost:5000/api/active_contract')
+    fetch('/api/active_contract')
       .then(res => res.json().then(js => ({ ok: res.ok, data: js })))
       .then(({ ok, data }) => {
         if (ok) setActiveURL(data.pdf_url);
@@ -36,7 +36,7 @@ function FillContract() {
       return;
     }
     try {
-      const res = await fetch('http://localhost:5000/api/create_personal', {
+      const res = await fetch('/api/create_personal', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(form)
@@ -67,7 +67,7 @@ function FillContract() {
               <p className="text-muted">
                 <strong>Step 1:</strong>{' '}
                 <a
-                  href={`http://localhost:5000${activeURL}`}
+                  href={activeURL}
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/src/components/ListPersonalized.js
+++ b/src/components/ListPersonalized.js
@@ -7,7 +7,7 @@ function ListPersonalized() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    fetch('http://localhost:5000/api/list_personalized_contracts')
+    fetch('/api/list_personalized_contracts')
       .then(res => res.json().then(js => ({ ok: res.ok, data: js })))
       .then(({ ok, data }) => {
         if (ok) setContracts(data);
@@ -58,7 +58,7 @@ function ListPersonalized() {
                       {c.is_signed && (
                         <a
                           className="btn btn-sm btn-outline-success"
-                          href={`http://localhost:5000${c.signed_url}`}
+                          href={c.signed_url}
                           target="_blank"
                           rel="noreferrer"
                         >

--- a/src/components/ListVersions.js
+++ b/src/components/ListVersions.js
@@ -5,7 +5,7 @@ function ListVersions() {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    fetch('http://localhost:5000/api/list_contract_versions')
+    fetch('/api/list_contract_versions')
       .then(res => res.json().then(js => ({ ok: res.ok, data: js })))
       .then(({ ok, data }) => {
         if (ok) setVersions(data);
@@ -15,7 +15,7 @@ function ListVersions() {
   }, []);
 
   const handleActivate = (id) => {
-    fetch('http://localhost:5000/api/activate_contract', {
+    fetch('/api/activate_contract', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ template_id: id })

--- a/src/components/PreviewSign.js
+++ b/src/components/PreviewSign.js
@@ -9,7 +9,7 @@ function PreviewSign() {
   const [pdfUrl, setPdfUrl] = useState('');
 
   useEffect(() => {
-    setPdfUrl(`http://localhost:5000/api/download_personal/${personalId}`);
+    setPdfUrl(`/api/download_personal/${personalId}`);
   }, [personalId]);
 
   const handleSave = () => {
@@ -24,7 +24,7 @@ function PreviewSign() {
     const rawCanvas = canvasInstance.getCanvas();
     const dataURL = rawCanvas.toDataURL('image/png');
 
-    fetch(`http://localhost:5000/api/sign_personal/${personalId}`, {
+    fetch(`/api/sign_personal/${personalId}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ signature: dataURL })
@@ -32,7 +32,7 @@ function PreviewSign() {
       .then(res => res.json().then(js => ({ ok: res.ok, data: js })))
       .then(({ ok, data }) => {
         if (ok) {
-          window.location.href = `http://localhost:5000${data.signed_url}`;
+          window.location.href = data.signed_url;
         } else {
           setError(data.error || 'Signing failed.');
         }

--- a/src/components/UploadContract.js
+++ b/src/components/UploadContract.js
@@ -23,7 +23,7 @@ function UploadContract() {
     formData.append('contract_pdf', file);
 
     try {
-      const res = await fetch('http://localhost:5000/api/upload_contract', {
+      const res = await fetch('/api/upload_contract', {
         method: 'POST',
         body: formData
       });

--- a/src/components/ViewActive.js
+++ b/src/components/ViewActive.js
@@ -5,7 +5,7 @@ function ViewActive() {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    fetch('http://localhost:5000/api/active_contract')
+    fetch('/api/active_contract')
       .then((res) => res.json().then(js => ({ ok: res.ok, data: js })))
       .then(({ ok, data }) => {
         if (ok) {
@@ -26,7 +26,7 @@ function ViewActive() {
       {template && (
         <>
           <iframe
-            src={`http://localhost:5000${template.pdf_url}`}
+            src={template.pdf_url}
             style={{ width: '100%', height: '75vh', border: '1px solid #ccc', borderRadius: '.25rem' }}
             title="Active Contract"
           ></iframe>


### PR DESCRIPTION
## Summary
- switch to relative API paths so the frontend works outside of localhost

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546bd3d0f08333b2f5212d4e593230